### PR TITLE
Fix: ng build dependency not found ; Pages still in v = 55

### DIFF
--- a/.github/workflows/Pages-docs-deploy-actions-moi.yml
+++ b/.github/workflows/Pages-docs-deploy-actions-moi.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '18.13'
       - run: npm install -g bats
       - run: bats -v
       - run: ls


### PR DESCRIPTION
trace : requires 18.13 https://github.com/moueza/Z-Anatomy/actions/runs/7768042628/job/21185533703