### PR TITLE
Fix: mkdir: cannot create directory ‘docs’: File exists

### DIFF
--- a/script-preprod.sh
+++ b/script-preprod.sh
@@ -2,5 +2,5 @@
  
 cd WEBSITE;ng build;cd ..
 
-rm -Rf docs/;  mkdir docs
-cp WEBSITE/dist/ ./docs
+rm -Rf docs/;  
+cp WEBSITE/dist/* ./docs


### PR DESCRIPTION
cp: -r not specified; omitting directory 'WEBSITE/dist/'